### PR TITLE
Enable build on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: rust
+rust:
+  - nightly
+addons:
+  apt:
+    packages:
+      - libsqlite3-dev
+env:
+  global:
+    - DATABASE_URL=test-database.sqlite
+    - PATH="/home/travis/.cargo/bin:$PATH"
+before_script:
+  - cargo install diesel_cli
+script:
+  - make migratedb
+  - cargo build

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 *Lugh* is a copy (writings, translations, etc.) manager that you can host on
 your server or computer.
 
+[![Build Status](https://travis-ci.org/rlustin/lugh.svg?branch=master)](https://travis-ci.org/rlustin/lugh)
+
 ## Install
 
 To make sure you don't run into trouble, make sure you have both `npm` and


### PR DESCRIPTION
Enable build on Travis CI for Rust nightly only, as some recent features of the language are used in the project.

@Signez, could you please review?