### PR TITLE
Ensure font-awesome is copied successfully during build

### DIFF
--- a/src/frontend/app/assets/index.html
+++ b/src/frontend/app/assets/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="initial-scale=1.0" />
   <title>Lugh</title>
   <link rel="stylesheet" href="/app.css" type="text/css">
-  <link rel="stylesheet" href="/fonts/css/font-awesome.min.css" type="text/css">
+  <link rel="stylesheet" href="/fonts/font-awesome.min.css" type="text/css">
   <script src="/vendor.js"></script>
 </head>
 <body>

--- a/src/frontend/brunch-config.js
+++ b/src/frontend/brunch-config.js
@@ -10,6 +10,14 @@ module.exports = {
   },
 
   plugins: {
-    babel: {presets: ['es2015']}
+    babel: {presets: ['es2015']},
+    copycat: {
+      "fonts": [
+        "node_modules/font-awesome/fonts",
+        "node_modules/font-awesome/css"
+      ],
+      "onlyChanged": true,
+      "verbose": false
+    }
   }
 };

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -19,6 +19,7 @@
     "babel-preset-es2015": "~6.3.13",
     "brunch": "^2.4.0",
     "clean-css-brunch": "^2.0.0",
+    "copycat-brunch": "github:cmelgarejo/copycat-brunch",
     "css-brunch": "^2.0.0",
     "font-awesome": "^4.7.0",
     "javascript-brunch": "^2.0.0",


### PR DESCRIPTION
During #3, I removed the `/src/frontend/public/` folder for goods, but it removed font-awesome ; this ensure fonts files are automatically pulled from npm on build.

@rlustin Please review and merge.