### PR TITLE
Use master branch of `diesel` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,8 +2,8 @@
 name = "lugh"
 version = "0.1.0"
 dependencies = [
- "diesel 0.8.1 (git+https://github.com/diesel-rs/diesel?branch=sg-bump-nightly)",
- "diesel_codegen 0.8.1 (git+https://github.com/diesel-rs/diesel?branch=sg-bump-nightly)",
+ "diesel 0.8.2 (git+https://github.com/diesel-rs/diesel)",
+ "diesel_codegen 0.8.2 (git+https://github.com/diesel-rs/diesel)",
  "dotenv 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.9.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "iron 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -72,17 +72,6 @@ dependencies = [
 [[package]]
 name = "diesel"
 version = "0.8.1"
-source = "git+https://github.com/diesel-rs/diesel?branch=sg-bump-nightly#3749638ea8b8065ade638b34885354ea83626379"
-dependencies = [
- "byteorder 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "libsqlite3-sys 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "pq-sys 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "diesel"
-version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -91,9 +80,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "diesel"
+version = "0.8.2"
+source = "git+https://github.com/diesel-rs/diesel#85a458b6d71b28d64067fd1c2d1e6de30f3e242f"
+dependencies = [
+ "byteorder 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libsqlite3-sys 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pq-sys 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "diesel_codegen"
-version = "0.8.1"
-source = "git+https://github.com/diesel-rs/diesel?branch=sg-bump-nightly#3749638ea8b8065ade638b34885354ea83626379"
+version = "0.8.2"
+source = "git+https://github.com/diesel-rs/diesel#85a458b6d71b28d64067fd1c2d1e6de30f3e242f"
 dependencies = [
  "diesel 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "diesel_codegen_shared 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -795,9 +795,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum byteorder 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)" = "29b2aa490a8f546381308d68fc79e6bd753cd3ad839f7a7172897f1feedfa175"
 "checksum conduit-mime-types 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "95ca30253581af809925ef68c2641cc140d6183f43e12e0af4992d53768bd7b8"
 "checksum cookie 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "0e3d6405328b6edb412158b3b7710e2634e23f3614b9bb1c412df7952489a626"
-"checksum diesel 0.8.1 (git+https://github.com/diesel-rs/diesel?branch=sg-bump-nightly)" = "<none>"
 "checksum diesel 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "932e6e3dead4069e67a4999f98395175b91533cab2901ff471c414101018f9a4"
-"checksum diesel_codegen 0.8.1 (git+https://github.com/diesel-rs/diesel?branch=sg-bump-nightly)" = "<none>"
+"checksum diesel 0.8.2 (git+https://github.com/diesel-rs/diesel)" = "<none>"
+"checksum diesel_codegen 0.8.2 (git+https://github.com/diesel-rs/diesel)" = "<none>"
 "checksum diesel_codegen_shared 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "09d4c594e4fce9b1dc34bf82220493204fffa323354f44f3c391824423986caf"
 "checksum dotenv 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "eea1395d2df3b5344dc577809296d9578303296e8d105c408aa80ed67d598ef1"
 "checksum dtoa 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0dd841b58510c9618291ffa448da2e4e0f699d984d436122372f446dae62263d"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,8 +4,8 @@ version = "0.1.0"
 authors = ["Raphaël Lustin <raphael@lustin.fr>"]
 
 [dependencies]
-diesel = { git = "https://github.com/diesel-rs/diesel", features = ["sqlite"], branch = "sg-bump-nightly" }
-diesel_codegen = { git = "https://github.com/diesel-rs/diesel", features = ["sqlite"], branch = "sg-bump-nightly" }
+diesel = { git = "https://github.com/diesel-rs/diesel", features = ["sqlite"] }
+diesel_codegen = { git = "https://github.com/diesel-rs/diesel", features = ["sqlite"] }
 dotenv = "0.8.0"
 iron = "*"
 params = "0.5.0"


### PR DESCRIPTION
As https://github.com/diesel-rs/diesel/pull/493 is merged, use master branch for building `diesel` crate.