### PR TITLE
Load fixtures on test execution

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,8 @@ addons:
       - libsqlite3-dev
 env:
   global:
-    - DATABASE_URL=/home/travis/lugh-test-database.sqlite
-    - LUGH_BIND=localhost:3000
+    - TEST_DATABASE_URL=/home/travis/lugh-test-database.sqlite
+    - TEST_LUGH_BIND=localhost:3000
     - PATH="/home/travis/.cargo/bin:$PATH"
 before_script:
   - cargo install diesel_cli

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Configuration is made in `.env` file:
 
 ```
 DATABASE_URL=database.sqlite
+LUGH_BIND=127.0.0.1:3000
 ```
 
 ## Migrate database
@@ -55,3 +56,13 @@ $ brunch watch
 Brunch will take care of downloading all what is necessary to run the frontend
 and build everything, then watch for your changes to build it to the
 `src/frontend/public` folder where the Rust part will serve it.
+
+## Tests
+
+So that you do not conflict with the development, use these environment variables:
+```
+TEST_DATABASE_URL=test-database.sqlite
+TEST_LUGH_BIND=127.0.0.1:3100
+```
+
+You can run the tests with `make test`.

--- a/migrations/20161029110638_create_translations/up.sql
+++ b/migrations/20161029110638_create_translations/up.sql
@@ -7,9 +7,3 @@ CREATE TABLE translations (
   deleted_at TEXT DEFAULT NULL
 );
 
-INSERT INTO translations (key, locale, content) VALUES ("ui.add", "fr", "ajouter");
-INSERT INTO translations (key, locale, content) VALUES ("ui.add", "de", "hinzufügen");
-INSERT INTO translations (key, locale, content) VALUES ("ui.add", "en", "add");
-INSERT INTO translations (key, locale, content) VALUES ("ui.add", "es", "añadir");
-INSERT INTO translations (key, locale, content) VALUES ("ui.add", "it", "aggiungi");
-INSERT INTO translations (key, locale, content) VALUES ("ui.add", "ru", "добавить");

--- a/tests/fixtures.sql
+++ b/tests/fixtures.sql
@@ -1,0 +1,6 @@
+INSERT INTO translations (key, locale, content) VALUES ("ui.add", "fr", "ajouter");
+INSERT INTO translations (key, locale, content) VALUES ("ui.add", "de", "hinzufügen");
+INSERT INTO translations (key, locale, content) VALUES ("ui.add", "en", "add");
+INSERT INTO translations (key, locale, content) VALUES ("ui.add", "es", "añadir");
+INSERT INTO translations (key, locale, content) VALUES ("ui.add", "it", "aggiungi");
+INSERT INTO translations (key, locale, content) VALUES ("ui.add", "ru", "добавить");

--- a/tools/test.sh
+++ b/tools/test.sh
@@ -13,13 +13,13 @@ trap teardown_on_error ERR
 
 cargo build
 
-diesel setup
+DATABASE_URL=$TEST_DATABASE_URL diesel setup
 
-LUGH_BIND=127.0.0.1:3100 target/debug/lugh &
+DATABASE_URL=$TEST_DATABASE_URL LUGH_BIND=$TEST_LUGH_BIND target/debug/lugh &
 
 LUGH_PID=$!
 
-LUGH_BIND=127.0.0.1:3100 cargo test
+DATABASE_URL=$TEST_DATABASE_URL LUGH_BIND=$TEST_LUGH_BIND cargo test
 
 teardown
 

--- a/tools/test.sh
+++ b/tools/test.sh
@@ -2,6 +2,7 @@
 
 function teardown {
   kill -SIGTERM $LUGH_PID
+  rm $TEST_DATABASE_URL
 }
 
 function teardown_on_error {
@@ -14,6 +15,8 @@ trap teardown_on_error ERR
 cargo build
 
 DATABASE_URL=$TEST_DATABASE_URL diesel setup
+
+sqlite3 $TEST_DATABASE_URL ".read tests/fixtures.sql"
 
 DATABASE_URL=$TEST_DATABASE_URL LUGH_BIND=$TEST_LUGH_BIND target/debug/lugh &
 


### PR DESCRIPTION
Also use test environment variables to avoid overwriting dev database.

@Signez, could you please review?