### PR TITLE
Prepare auth

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ addons:
       - libsqlite3-dev
 env:
   global:
+    - DATABASE_BUSY_TIMEOUT=250
     - TEST_DATABASE_URL=/home/travis/lugh-test-database.sqlite
     - TEST_LUGH_BIND=localhost:3000
     - PATH="/home/travis/.cargo/bin:$PATH"

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Configuration is made in `.env` file:
 
 ```
 DATABASE_URL=database.sqlite
+DATABASE_BUSY_TIMEOUT=250
 LUGH_BIND=127.0.0.1:3000
 ```
 

--- a/src/api/v1/common.rs
+++ b/src/api/v1/common.rs
@@ -1,0 +1,12 @@
+use errors::BadRequestError;
+use iron::prelude::*;
+use params::{Params, Value};
+
+pub fn get_param(request: &mut Request, name: &str) -> Result<String, BadRequestError> {
+    let parameters = request.get_ref::<Params>().unwrap();
+
+    match parameters.find(&[name]) {
+        Some(&Value::String(ref value)) => Ok(value.clone()),
+        _ => Err(BadRequestError(format!("You must provide a {}", name))),
+    }
+}

--- a/src/api/v1/mod.rs
+++ b/src/api/v1/mod.rs
@@ -1,0 +1,9 @@
+use iron::prelude::*;
+use iron::status;
+
+pub mod common;
+pub mod translations;
+
+pub fn index(_: &mut Request) -> IronResult<Response> {
+    Ok(Response::with((status::Ok, "Welcome to Lugh API!")))
+}

--- a/src/api/v1/translations.rs
+++ b/src/api/v1/translations.rs
@@ -13,7 +13,7 @@ use super::common::*;
 pub fn index(_: &mut Request) -> IronResult<Response> {
     use std::collections::HashMap;
 
-    let connection = database::establish_connection();
+    let connection = try!(database::establish_connection());
     let results = translations.filter(
             sql("key || locale || created_at IN (
                   SELECT key || locale || MAX(created_at)
@@ -61,7 +61,7 @@ pub fn create(request: &mut Request) -> IronResult<Response> {
         content: new_content,
     };
 
-    let connection = database::establish_connection();
+    let connection = try!(database::establish_connection());
 
     diesel::insert(&new_translation)
         .into(translations::table)
@@ -85,7 +85,7 @@ pub fn delete(request: &mut Request) -> IronResult<Response> {
 
     let key_to_delete = try!(get_param(request, "key"));
 
-    let connection = database::establish_connection();
+    let connection = try!(database::establish_connection());
 
     let now = time::strftime("%F %T", &time::now_utc()).unwrap();
 

--- a/src/api/v1/translations.rs
+++ b/src/api/v1/translations.rs
@@ -1,22 +1,16 @@
-extern crate iron;
-extern crate rustc_serialize;
-
 use iron::headers::ContentType;
 use iron::prelude::*;
 use iron::status;
 use diesel::expression::dsl::sql;
 use diesel::prelude::*;
-use errors::*;
 use models::*;
 use rustc_serialize::json;
 use schema::translations::dsl::*;
+
 use database;
+use super::common::*;
 
 pub fn index(_: &mut Request) -> IronResult<Response> {
-    Ok(Response::with((status::Ok, "Welcome to Lugh API!")))
-}
-
-pub fn translations_index(_: &mut Request) -> IronResult<Response> {
     use std::collections::HashMap;
 
     let connection = database::establish_connection();
@@ -53,32 +47,18 @@ pub fn translations_index(_: &mut Request) -> IronResult<Response> {
     Ok(Response::with((ContentType::json().0, status::Ok, payload)))
 }
 
-pub fn translations_create(request: &mut Request) -> IronResult<Response> {
+pub fn create(request: &mut Request) -> IronResult<Response> {
     use diesel;
-    use params::{Params, Value};
     use schema::translations;
 
-    let parameters = request.get_ref::<Params>().unwrap();
-
-    let new_key = match parameters.find(&["key"]) {
-        Some(&Value::String(ref new_key)) => new_key,
-        _ => return bad_request_error("You must provide a key"),
-    };
-
-    let new_locale = match parameters.find(&["locale"]) {
-        Some(&Value::String(ref new_locale)) => new_locale,
-        _ => return bad_request_error("You must provide a locale"),
-    };
-
-    let new_content = match parameters.find(&["content"]) {
-        Some(&Value::String(ref new_content)) => new_content,
-        _ => return bad_request_error("You must provide a content"),
-    };
+    let new_key = try!(get_param(request, "key"));
+    let new_locale = try!(get_param(request, "locale"));
+    let new_content = try!(get_param(request, "content"));
 
     let new_translation = NewTranslation {
-        key: new_key.to_string(),
-        locale: new_locale.to_string(),
-        content: new_content.to_string(),
+        key: new_key,
+        locale: new_locale,
+        content: new_content,
     };
 
     let connection = database::establish_connection();
@@ -99,31 +79,21 @@ pub fn translations_create(request: &mut Request) -> IronResult<Response> {
     Ok(Response::with((ContentType::json().0, status::Created, payload)))
 }
 
-pub fn translations_delete(request: &mut Request) -> IronResult<Response> {
+pub fn delete(request: &mut Request) -> IronResult<Response> {
     use diesel;
-    use params::{Params, Value};
     use time;
 
-    let parameters = request.get_ref::<Params>().unwrap();
-
-    let key_to_delete = match parameters.find(&["key"]) {
-        Some(&Value::String(ref key_to_delete)) => key_to_delete,
-        _ => return bad_request_error("You must provide a key to delete"),
-    };
+    let key_to_delete = try!(get_param(request, "key"));
 
     let connection = database::establish_connection();
 
     let now = time::strftime("%F %T", &time::now_utc()).unwrap();
 
-    diesel::update(translations.filter(key.eq(key_to_delete))
+    diesel::update(translations.filter(key.eq(&key_to_delete))
                    .filter(deleted_at.is_null()))
         .set(deleted_at.eq(now))
         .execute(&connection)
-        .expect(&format!("Unable to delete translations with key={}", key_to_delete));
+        .expect(&format!("Unable to delete translations with key={}", &key_to_delete));
 
     Ok(Response::with((ContentType::json().0, status::NoContent)))
-}
-
-fn bad_request_error(message: &'static str) -> Result<Response, IronError> {
-    Err(IronError::new(StringError(message), status::BadRequest))
 }

--- a/src/database.rs
+++ b/src/database.rs
@@ -1,14 +1,16 @@
 use diesel::prelude::*;
 use diesel::sqlite::SqliteConnection;
 use dotenv::dotenv;
+use errors::StringError;
 use std::env;
 
-pub fn establish_connection() -> SqliteConnection {
+pub fn establish_connection() -> Result<SqliteConnection, StringError> {
     dotenv().ok();
 
     let database_url = env::var("DATABASE_URL")
         .expect("DATABASE_URL must be set");
 
-    SqliteConnection::establish(&database_url)
-        .expect(&format!("Error connecting to {}", database_url))
+    let connection = try!(SqliteConnection::establish(&database_url));
+
+    Ok(connection)
 }

--- a/src/database.rs
+++ b/src/database.rs
@@ -7,10 +7,12 @@ use std::env;
 pub fn establish_connection() -> Result<SqliteConnection, StringError> {
     dotenv().ok();
 
-    let database_url = env::var("DATABASE_URL")
-        .expect("DATABASE_URL must be set");
+    let database_url = env::var("DATABASE_URL").expect("DATABASE_URL must be set");
+    let busy_timeout = env::var("DATABASE_BUSY_TIMEOUT").unwrap_or("250".to_string());
 
     let connection = try!(SqliteConnection::establish(&database_url));
+
+    try!(connection.execute(format!("PRAGMA busy_timeout = {};", busy_timeout).as_str()));
 
     Ok(connection)
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,6 +1,31 @@
+use diesel::ConnectionError as DieselConnectionError;
+use diesel::result::Error as DieselResultError;
+use iron::prelude::*;
+use iron::status;
 use std::error::Error;
 use std::fmt::{self, Debug};
+use std::string::FromUtf8Error;
 
+#[derive(Debug)]
+pub struct BadRequestError(pub String);
+
+impl fmt::Display for BadRequestError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        Debug::fmt(self, f)
+    }
+}
+
+impl Error for BadRequestError {
+    fn description(&self) -> &str { &*self.0.as_str() }
+}
+
+impl From<BadRequestError> for IronError {
+    fn from(error: BadRequestError) -> IronError {
+        IronError::new(error, status::BadRequest)
+    }
+}
+
+// FIXME: Remove this generic error once all errors are implemented
 #[derive(Debug)]
 pub struct StringError(pub &'static str);
 
@@ -12,4 +37,28 @@ impl fmt::Display for StringError {
 
 impl Error for StringError {
     fn description(&self) -> &str { &*self.0 }
+}
+
+impl From<DieselConnectionError> for StringError {
+    fn from(_: DieselConnectionError) -> StringError {
+        StringError("Database connection error")
+    }
+}
+
+impl From<DieselResultError> for StringError {
+    fn from(_: DieselResultError) -> StringError {
+        StringError("ORM result error")
+    }
+}
+
+impl From<FromUtf8Error> for StringError {
+    fn from(_: FromUtf8Error) -> StringError {
+        StringError("Error when parsing bytes to String")
+    }
+}
+
+impl From<StringError> for IronError {
+    fn from(error: StringError) -> IronError {
+        IronError::new(error, status::InternalServerError)
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,9 +30,9 @@ fn main() {
 
     let mut router = Router::new();
     router.get("/", api::v1::index, "api");
-    router.get("/translations", api::v1::translations_index, "translations_index");
-    router.post("/translations", api::v1::translations_create, "translations_create");
-    router.delete("/translations", api::v1::translations_delete, "translations_delete");
+    router.get("/translations", api::v1::translations::index, "translations_index");
+    router.post("/translations", api::v1::translations::create, "translations_create");
+    router.delete("/translations", api::v1::translations::delete, "translations_delete");
 
     let mut mount = Mount::new();
     mount.mount("/", Static::new(Path::new("src/frontend/public/")));

--- a/tests/api/v1/common.rs
+++ b/tests/api/v1/common.rs
@@ -1,0 +1,74 @@
+use hyper::*;
+use hyper::client::Response;
+use hyper::header::Headers;
+use std::io::Read;
+
+pub fn delete(path: &'static str, body: String) -> (Response, String) {
+    let mut response = Client::new()
+        .delete(&url(path))
+        .headers(application_json_headers())
+        .body(&body)
+        .send()
+        .unwrap();
+
+    let mut content = String::new();
+    response.read_to_string(&mut content).unwrap();
+
+    (response, content)
+}
+
+pub fn get(path: &'static str) -> (Response, String) {
+    let mut response = Client::new()
+        .get(&url(path))
+        .send()
+        .unwrap();
+
+    let mut result = String::new();
+    response.read_to_string(&mut result).unwrap();
+
+    (response, result)
+}
+
+pub fn post(path: &'static str, body: String) -> (Response, String) {
+    let mut response = Client::new()
+        .post(&url(path))
+        .headers(application_json_headers())
+        .body(&body)
+        .send()
+        .unwrap();
+
+    let mut content = String::new();
+    response.read_to_string(&mut content).unwrap();
+
+    (response, content)
+}
+
+fn application_json_headers() -> Headers {
+    use hyper::header::{Headers, ContentType};
+    use hyper::mime::{Mime, TopLevel, SubLevel, Attr, Value};
+
+    let mut headers = Headers::new();
+    headers.set(
+        ContentType(
+            Mime(
+                TopLevel::Application,
+                SubLevel::Json,
+                vec![(Attr::Charset, Value::Utf8)]
+            )
+        )
+    );
+
+    headers
+}
+
+fn url(path: &'static str) -> String {
+    use dotenv::dotenv;
+    use std::env;
+
+    dotenv().ok();
+
+    let hostname = env::var("LUGH_BIND")
+        .expect("LUGH_BIND must be set");
+
+    "http://".to_string() + hostname.as_str() + path
+}

--- a/tests/api/v1/mod.rs
+++ b/tests/api/v1/mod.rs
@@ -1,0 +1,17 @@
+mod common;
+mod translations;
+
+#[cfg(test)]
+mod tests {
+    use super::common::*;
+
+    use hyper::status::StatusCode;
+
+    #[test]
+    fn test_index() {
+        let (response, result) = get("/api/v1");
+
+        assert_eq!(response.status, StatusCode::Ok);
+        assert_eq!(result, "Welcome to Lugh API!");
+    }
+}

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -1,5 +1,10 @@
 #!/bin/bash -ex
 
+if [ -z $DATABASE_URL ]; then
+  echo "DATABASE_URL is not set. Aborting."
+  exit 1;
+fi
+
 command -v rustup >/dev/null 2>&1 || { echo 'I require `rustup` but it’s not installed. Install it with `curl https://sh.rustup.rs -sSf | sh`. Aborting.' >&2; exit 1; }
 
 sudo apt install libsqlite3-dev

--- a/tools/test.sh
+++ b/tools/test.sh
@@ -1,5 +1,15 @@
 #!/bin/bash -ex
 
+if [ -z $TEST_DATABASE_URL ]; then
+  echo "TEST_DATABASE_URL is not set. Aborting."
+  exit 1;
+fi
+
+if [ -z $TEST_LUGH_BIND ]; then
+  echo "TEST_LUGH_BIND is not set. Aborting."
+  exit 1;
+fi
+
 function teardown {
   kill -SIGTERM $LUGH_PID
   rm $TEST_DATABASE_URL
@@ -22,7 +32,7 @@ DATABASE_URL=$TEST_DATABASE_URL LUGH_BIND=$TEST_LUGH_BIND target/debug/lugh &
 
 LUGH_PID=$!
 
-DATABASE_URL=$TEST_DATABASE_URL LUGH_BIND=$TEST_LUGH_BIND cargo test
+DATABASE_URL=$TEST_DATABASE_URL LUGH_BIND=$TEST_LUGH_BIND cargo test -- --nocapture
 
 teardown
 


### PR DESCRIPTION
I’ve slitted the authentication work in many PR to facilitate the review.

This PR prepares the arrival of other controllers:
- Test env var on install and test script;
- Get parameters in a helper common to API controllers;
- Use Result error handling pattern for database connection;
- Set sqlite busy timeout from env variable.

@Signez, could you please review?