### PR TITLE
Translation history

### DIFF
--- a/src/api/v1/translations.rs
+++ b/src/api/v1/translations.rs
@@ -79,6 +79,24 @@ pub fn create(request: &mut Request) -> IronResult<Response> {
     Ok(Response::with((ContentType::json().0, status::Created, payload)))
 }
 
+pub fn show(request: &mut Request) -> IronResult<Response> {
+    use router::Router;
+
+    let ref translation_key = request.extensions.get::<Router>().unwrap().find("key").unwrap();
+
+    let connection = try!(database::establish_connection());
+
+    let all_translations = translations.filter(key.eq(translation_key))
+        .load::<Translation>(&connection)
+        .expect("Error loading translations");
+
+    println!("Returns {} translations", all_translations.len());
+
+    let payload = json::encode(&all_translations).unwrap();
+
+    Ok(Response::with((ContentType::json().0, status::Ok, payload)))
+}
+
 pub fn delete(request: &mut Request) -> IronResult<Response> {
     use diesel;
     use router::Router;

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,6 +39,7 @@ fn main() {
 
     router.get("/translations", api::v1::translations::index, "translations_index");
     router.post("/translations", api::v1::translations::create, "translations_create");
+    router.get("/translations/:key", api::v1::translations::show, "translations_show");
     router.delete("/translations/:key", api::v1::translations::delete, "translations_delete");
 
     router.post("/users", api::v1::users::create, "users_create");

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,7 +39,7 @@ fn main() {
 
     router.get("/translations", api::v1::translations::index, "translations_index");
     router.post("/translations", api::v1::translations::create, "translations_create");
-    router.delete("/translations", api::v1::translations::delete, "translations_delete");
+    router.delete("/translations/:key", api::v1::translations::delete, "translations_delete");
 
     router.post("/users", api::v1::users::create, "users_create");
 

--- a/tests/api/v1/common.rs
+++ b/tests/api/v1/common.rs
@@ -3,11 +3,10 @@ use hyper::client::Response;
 use hyper::header::Headers;
 use std::io::Read;
 
-pub fn delete(path: &'static str, body: String, token: Option<String>) -> (Response, String) {
+pub fn delete(path: &'static str, token: Option<String>) -> (Response, String) {
     let mut response = Client::new()
         .delete(&url(path))
         .headers(headers(token))
-        .body(&body)
         .send()
         .unwrap();
 


### PR DESCRIPTION
This PR adds the endpoint `GET /api/v1/translations/:key` to get the complete history of a translation key.

```bash
curl -v -H "Authorization: Bearer [token]" -H "Content-Type: application/json" http://127.0.0.1:3100/api/v1/translations/hey.you
```

```json
[
    {
        "content": "Hey toi\u00a0!",
        "created_at": "2016-12-11 16:31:11",
        "deleted_at": "2016-12-11 16:32:18",
        "id": 23,
        "key": "hey.you",
        "locale": "fr"
    },
    {
        "content": "Hey toi\u00a0!",
        "created_at": "2016-12-11 16:31:20",
        "deleted_at": "2016-12-11 16:32:18",
        "id": 24,
        "key": "hey.you",
        "locale": "fr"
    },
    {
        "content": "Hey!",
        "created_at": "2016-12-11 16:31:29",
        "deleted_at": "2016-12-11 16:32:18",
        "id": 25,
        "key": "hey.you",
        "locale": "en"
    },
    {
        "content": "Hey you!",
        "created_at": "2016-12-11 16:31:36",
        "deleted_at": "2016-12-11 16:32:18",
        "id": 26,
        "key": "hey.you",
        "locale": "en"
    },
    {
        "content": "Hey you!",
        "created_at": "2016-12-11 16:32:27",
        "deleted_at": null,
        "id": 27,
        "key": "hey.you",
        "locale": "en"
    },
    {
        "content": "Hey toi\u00a0!",
        "created_at": "2016-12-11 16:32:33",
        "deleted_at": null,
        "id": 28,
        "key": "hey.you",
        "locale": "fr"
    }
]
```

It also uses key in URL to delete translations.
