### PR TITLE
Lint code with clippy

### DIFF
--- a/src/api/v1/translations.rs
+++ b/src/api/v1/translations.rs
@@ -28,7 +28,7 @@ pub fn index(_: &mut Request) -> IronResult<Response> {
 
     for translation in &results {
       let mut translations_for_key = all_translations.entry(&translation.key)
-          .or_insert(Vec::<TranslationForLocale>::new());
+          .or_insert_with(Vec::<TranslationForLocale>::new);
 
       translations_for_key.push(
           TranslationForLocale {
@@ -82,7 +82,7 @@ pub fn create(request: &mut Request) -> IronResult<Response> {
 pub fn show(request: &mut Request) -> IronResult<Response> {
     use router::Router;
 
-    let ref translation_key = request.extensions.get::<Router>().unwrap().find("key").unwrap();
+    let translation_key = request.extensions.get::<Router>().unwrap().find("key").unwrap();
 
     let connection = try!(database::establish_connection());
 

--- a/src/authentication/middleware.rs
+++ b/src/authentication/middleware.rs
@@ -8,7 +8,7 @@ use super::*;
 pub struct AuthenticationMiddleware;
 
 impl AuthenticationMiddleware {
-    fn authorize(&self, token: &String) -> Result<Session, StringError> {
+    fn authorize(&self, token: &str) -> Result<Session, StringError> {
         authenticate_token(token)
     }
 

--- a/src/authentication/mod.rs
+++ b/src/authentication/mod.rs
@@ -5,7 +5,7 @@ use models::*;
 
 pub mod middleware;
 
-pub fn authenticate_user(email: &String, password: &String) -> Result<(User, Session), StringError> {
+pub fn authenticate_user(email: &str, password: &str) -> Result<(User, Session), StringError> {
     let user = try!(retrieve_user(&email));
 
     try!(verify_password(&user, &password));
@@ -15,7 +15,7 @@ pub fn authenticate_user(email: &String, password: &String) -> Result<(User, Ses
     Ok((user, session))
 }
 
-pub fn authenticate_token(auth_token: &String) -> Result<Session, StringError> {
+pub fn authenticate_token(auth_token: &str) -> Result<Session, StringError> {
     use schema::sessions::dsl::*;
     use time;
 
@@ -35,7 +35,7 @@ pub fn authenticate_token(auth_token: &String) -> Result<Session, StringError> {
     }
 }
 
-pub fn create_user(new_email: &String, new_password: &String) -> Result<User, StringError> {
+pub fn create_user(new_email: &str, new_password: &str) -> Result<User, StringError> {
     use diesel;
     use diesel::expression::dsl::sql;
     use schema::users::dsl::*;
@@ -82,7 +82,7 @@ pub fn delete_session(token_to_delete: String) -> Result<(), StringError> {
     }
 }
 
-pub fn retrieve_user(user_email: &String) -> Result<User, StringError> {
+pub fn retrieve_user(user_email: &str) -> Result<User, StringError> {
     use schema::users::dsl::*;
 
     let connection = try!(database::establish_connection());
@@ -130,7 +130,7 @@ fn generate_token() -> Result<String, StringError> {
     Ok(token)
 }
 
-fn hash_password(ref password: &String) -> Result<String, StringError> {
+fn hash_password(password: &str) -> Result<String, StringError> {
     use pwhash::bcrypt;
 
     match bcrypt::hash(password) {
@@ -139,12 +139,13 @@ fn hash_password(ref password: &String) -> Result<String, StringError> {
     }
 }
 
-fn verify_password(user: &User, password: &String) -> Result<(), StringError> {
+fn verify_password(user: &User, password: &str) -> Result<(), StringError> {
     use pwhash::bcrypt;
 
-    match bcrypt::verify(password.as_str(), &user.hashed_password.as_str()) {
-        true => Ok(()),
-        false => Err(StringError("Authentication failed")),
+    if bcrypt::verify(password, user.hashed_password.as_str()) {
+        Ok(())
+    } else {
+        Err(StringError("Authentication failed"))
     }
 }
 

--- a/tests/api/v1/common.rs
+++ b/tests/api/v1/common.rs
@@ -58,10 +58,9 @@ fn headers(token: Option<String>) -> Headers {
 
     let mut headers = Headers::new();
 
-    match token {
-        Some(token) => headers.set(Authorization(Bearer { token: token })),
-        None => {},
-    };
+    if let Some(token) = token {
+        headers.set(Authorization(Bearer { token: token }))
+    }
 
     headers.set(
         ContentType(

--- a/tests/api/v1/translations.rs
+++ b/tests/api/v1/translations.rs
@@ -185,12 +185,12 @@ mod tests {
         assert_eq!(0, result.deleted_translations);
     }
 
-    fn parse_translations_by_locales(ref content: &String) -> HashMap<String, Vec<TranslationForLocale>> {
-        json::decode(&content).unwrap()
+    fn parse_translations_by_locales(content: &str) -> HashMap<String, Vec<TranslationForLocale>> {
+        json::decode(content).unwrap()
     }
 
-    fn parse_translations(ref content: &String) -> Vec<Translation> {
-        json::decode(&content).unwrap()
+    fn parse_translations(content: &str) -> Vec<Translation> {
+        json::decode(content).unwrap()
     }
 
     fn post_translation(translation: NewTranslation, token: Option<String>) -> (Response, String) {


### PR DESCRIPTION
As suggested, here is a PR to lint the code with [clippy](https://github.com/Manishearth/rust-clippy).

Thanks for the idea!

Fix warnings:
- match_bool;
- needless_borrow;
- or_fun_call;
- ptr_arg;
- single_match;
- toplevel_ref_arg.

Could you please review @Signez?