### PR TITLE
Log error, elapsed time and http status code

### DIFF
--- a/src/logger.rs
+++ b/src/logger.rs
@@ -7,11 +7,29 @@ use time::precise_time_ns;
 
 pub struct RequestLogger;
 
+impl RequestLogger {
+    fn start(&self, request: &mut Request) {
+        request.extensions.insert::<RequestLogger>(precise_time_ns());
+    }
+
+    fn elapsed_time(&self, request: &mut Request) -> Result<u64, IronError> {
+        let start_time = *request.extensions.get::<RequestLogger>().unwrap();
+        let delta = (precise_time_ns() - start_time) as i64;
+
+        if delta <= 0 {
+            Ok(0)
+        } else {
+            Ok(((delta as f64) / 1000000.0).round() as u64)
+        }
+    }
+}
+
 impl typemap::Key for RequestLogger { type Value = u64; }
 
 impl BeforeMiddleware for RequestLogger {
     fn before(&self, request: &mut Request) -> IronResult<()> {
-        request.extensions.insert::<RequestLogger>(precise_time_ns());
+        self.start(request);
+
         println!(
             "Started {} \"{}\" for {} at {}",
             request.method,
@@ -26,9 +44,19 @@ impl BeforeMiddleware for RequestLogger {
 
 impl AfterMiddleware for RequestLogger {
     fn after(&self, request: &mut Request, response: Response) -> IronResult<Response> {
-        let delta = precise_time_ns() - *request.extensions.get::<RequestLogger>().unwrap();
-        println!("Request took {} ms", (delta as f64) / 1000000.0);
+        println!("{} ({} ms)", response.status.unwrap(), self.elapsed_time(request)?);
 
         Ok(response)
+    }
+
+    fn catch(&self, request: &mut Request, err: IronError) -> IronResult<Response> {
+        println!(
+            "{}: {} ({} ms)",
+            err.response.status.unwrap(),
+            err.error,
+            self.elapsed_time(request)?
+        );
+
+        Err(err)
     }
 }


### PR DESCRIPTION
Also:
- round time on milliseconds;
- show 0 ms if time goes backwards (related to [Cloudflare leap second bug](https://blog.cloudflare.com/how-and-why-the-leap-second-affected-cloudflare-dns/)).

Logs now look like:
```
Start application on 127.0.0.1:3100
Started GET "/api/v1/translations" for 127.0.0.1:59578 at 2017-01-02T23:49:07+01:00
Returns 1 translations
200 OK (25 ms)
Started POST "/api/v1/translations/1/validate" for 127.0.0.1:57952 at 2017-01-02T23:47:28+01:00
204 No Content (55 ms)
Started POST "/api/v1/translations/1/validat" for 127.0.0.1:57978 at 2017-01-02T23:47:30+01:00
404 Not Found: No matching route found. (15 ms)
```

@Signez, could you please review?