### PR TITLE
Return a bad request when body is empty

### DIFF
--- a/src/api/v1/common.rs
+++ b/src/api/v1/common.rs
@@ -21,7 +21,7 @@ pub fn now_str() -> Result<String, LughError> {
 }
 
 pub fn get_param(request: &mut Request, name: &str) -> Result<String, LughError> {
-    let parameters = request.get_ref::<Params>().unwrap();
+    let parameters = request.get_ref::<Params>()?;
 
     match parameters.find(&[name]) {
         Some(&Value::String(ref value)) => Ok(value.clone()),

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -5,6 +5,7 @@ use iron::status;
 use std::error::Error;
 use std::fmt;
 use std::string::FromUtf8Error;
+use params::ParamsError;
 use time::ParseError;
 
 #[derive(Debug)]
@@ -74,6 +75,12 @@ impl From<DieselResultError> for LughError {
 impl From<FromUtf8Error> for LughError {
     fn from(_: FromUtf8Error) -> LughError {
         LughError::ParseFailed("Parse from UTF8 error".to_string())
+    }
+}
+
+impl From<ParamsError> for LughError {
+    fn from(error: ParamsError) -> LughError {
+        LughError::BadRequest(error.description().to_string())
     }
 }
 

--- a/tests/api/v1/sessions.rs
+++ b/tests/api/v1/sessions.rs
@@ -20,6 +20,14 @@ mod tests {
     }
 
     #[test]
+    fn test_login_without_body() {
+        let (response, content) = post("/api/v1/login", None, None);
+
+        assert_eq!(StatusCode::BadRequest, response.status);
+        assert_eq!("", content)
+    }
+
+    #[test]
     fn test_login_without_email() {
         let login_params = LoginParams {
             email: None,

--- a/tests/api/v1/translations.rs
+++ b/tests/api/v1/translations.rs
@@ -44,6 +44,14 @@ mod tests {
     }
 
     #[test]
+    fn test_create_without_body() {
+        let (response, content) = post("/api/v1/translations", None, valid_token());
+
+        assert_eq!(StatusCode::BadRequest, response.status);
+        assert_eq!("", content)
+    }
+
+    #[test]
     fn test_create_without_token() {
         let new_translation = NewTranslation {
             key: Some("test.i_love_train"),

--- a/tests/api/v1/users.rs
+++ b/tests/api/v1/users.rs
@@ -13,6 +13,14 @@ mod tests {
     }
 
     #[test]
+    fn test_create_without_body() {
+        let (response, content) = post("/api/v1/users", None, valid_token());
+
+        assert_eq!(StatusCode::BadRequest, response.status);
+        assert_eq!("", content)
+    }
+
+    #[test]
     fn test_create_without_token() {
         let new_user = NewUser {
             email: Some("user@domain.com"),


### PR DESCRIPTION
It prevent internal server errors when doing requests with an empty body:

```
Started POST "/api/v1/login" for [::1]:58404 at 2017-01-08T16:39:43+01:00
thread '<unnamed>' panicked at 'called `Result::unwrap()` on an `Err` value: BodyError(BodyError { detail: "Can\'t parse body to JSON", cause: JsonError(Syntax(EOFWhileParsingValue, 1, 0)) })', /buildslave/rust-buildbot/slave/nightly-dist-rustc-linux/build/src/libcore/result.rs:845
```