### PR TITLE
Add a middleware to check `Content-Type` header on API

### DIFF
--- a/src/api/middleware/mod.rs
+++ b/src/api/middleware/mod.rs
@@ -1,0 +1,37 @@
+extern crate iron;
+
+use iron::prelude::*;
+use iron::BeforeMiddleware;
+use iron::mime::{Mime, SubLevel, TopLevel};
+
+pub struct ContentTypeMiddleware;
+
+impl ContentTypeMiddleware {
+    fn bad_request_error(&self) -> Result<(), IronError> {
+        use iron::status;
+        use errors::LughError;
+
+        Err(IronError {
+            error: Box::new(
+              LughError::BadRequest("`Content-Type` header must be set to `application/json`".to_string())
+            ),
+            response: Response::with(status::BadRequest),
+        })
+    }
+}
+
+impl BeforeMiddleware for ContentTypeMiddleware {
+    fn before(&self, request: &mut Request) -> IronResult<()> {
+        use iron::headers::*;
+
+        match request.headers.get::<ContentType>() {
+            Some(&ContentType(Mime(ref top_level, ref sub_level, _))) => {
+                match (top_level, sub_level) {
+                    (&TopLevel::Application, &SubLevel::Json) => Ok(()),
+                    (_, _) => self.bad_request_error(),
+                }
+            },
+            None => self.bad_request_error(),
+        }
+    }
+}

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,1 +1,2 @@
 pub mod v1;
+pub mod middleware;

--- a/src/authentication/mod.rs
+++ b/src/authentication/mod.rs
@@ -6,9 +6,9 @@ use models::*;
 pub mod middleware;
 
 pub fn authenticate_user(email: &str, password: &str) -> Result<(User, Session), LughError> {
-    let user = retrieve_user(&email)?;
+    let user = retrieve_user(email)?;
 
-    verify_password(&user, &password)?;
+    verify_password(&user, password)?;
 
     let session = create_session(&user)?;
 
@@ -41,7 +41,7 @@ pub fn create_user(new_email: &str, new_password: &str) -> Result<User, LughErro
     use schema::users::dsl::*;
     use schema::users::table;
 
-    let new_hashed_password = hash_password(&new_password)?;
+    let new_hashed_password = hash_password(new_password)?;
 
     let new_user = NewUser {
         email: new_email.to_string(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,6 +47,7 @@ fn main() {
 
     let mut api_chain = Chain::new(router);
     api_chain.link_before(authentication::middleware::AuthenticationMiddleware);
+    api_chain.link_before(api::middleware::ContentTypeMiddleware);
 
     let mut mount = Mount::new();
     mount.mount("/", Static::new(Path::new("src/frontend/public/")));

--- a/tests/api/v1/common.rs
+++ b/tests/api/v1/common.rs
@@ -48,6 +48,18 @@ pub fn post(path: &'static str, body: Option<String>, token: Option<String>) -> 
     (response, content)
 }
 
+pub fn url(path: &'static str) -> String {
+    use dotenv::dotenv;
+    use std::env;
+
+    dotenv().ok();
+
+    let hostname = env::var("LUGH_BIND")
+        .expect("LUGH_BIND must be set");
+
+    "http://".to_string() + hostname.as_str() + path
+}
+
 pub fn valid_token() -> Option<String> {
     Some("goodtokenfortests".to_string())
 }
@@ -83,16 +95,4 @@ fn headers(token: Option<String>) -> Headers {
     );
 
     headers
-}
-
-fn url(path: &'static str) -> String {
-    use dotenv::dotenv;
-    use std::env;
-
-    dotenv().ok();
-
-    let hostname = env::var("LUGH_BIND")
-        .expect("LUGH_BIND must be set");
-
-    "http://".to_string() + hostname.as_str() + path
 }

--- a/tests/api/v1/mod.rs
+++ b/tests/api/v1/mod.rs
@@ -32,4 +32,26 @@ mod tests {
         assert_eq!(response.status, StatusCode::Unauthorized);
         assert_eq!(result, "");
     }
+
+    #[test]
+    fn test_index_without_content_type() {
+        use hyper::*;
+        use hyper::header::{Authorization, Bearer, Headers};
+        use std::io::Read;
+
+        let mut headers = Headers::new();
+        headers.set(Authorization(Bearer { token: valid_token().unwrap() }));
+
+        let mut response = Client::new()
+            .get(&url("/api/v1"))
+            .headers(headers)
+            .send()
+            .unwrap();
+
+        let mut result = String::new();
+        response.read_to_string(&mut result).unwrap();
+
+        assert_eq!(StatusCode::BadRequest, response.status);
+        assert_eq!("", result);
+    }
 }


### PR DESCRIPTION
Following the errors encountered during development.

Also fix clippy warnings on a needless borrow.

@Signez, could you please review?