### PR TITLE
Install and build on macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,7 @@ migratedb:
 	diesel migration run
 
 build:
-	cargo build
-	(cd ./src/frontend && brunch build)
+	tools/build.sh
 
 run: build
 	cargo run

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -1,0 +1,13 @@
+#!/bin/bash -ex
+
+# Cargo
+if [[ "$OSTYPE" == "darwin"* ]]; then
+	# macOS
+	# Let’s assume openssl was installed via homebrew
+	export OPENSSL_INCLUDE_DIR=`brew --prefix openssl`/include
+	export OPENSSL_LIB_DIR=`brew --prefix openssl`/lib
+fi
+cargo build
+
+# Brunch
+cd ./src/frontend && brunch build

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -1,12 +1,18 @@
 #!/bin/bash -ex
 
+# libsqlite3-dev
+if [[ "$OSTYPE" == "linux-gnu" ]]; then
+	sudo apt update
+	sudo apt install libsqlite3-dev
+elif [[ "$OSTYPE" == "darwin"* ]]; then
+	# macOS
+	# libsqlite3-dev is installed by default on any recent macOS
+else
+    echo "error can't install package `libsqlite3-dev`, unknown OS $OSTYPE"
+    exit 1;
+fi
 
 command -v rustup >/dev/null 2>&1 || { echo 'I require `rustup` but it’s not installed. Install it with `curl https://sh.rustup.rs -sSf | sh`. Aborting.' >&2; exit 1; }
-
-sudo apt update
-
-sudo apt install libsqlite3-dev
-
 rustup override set nightly
 
 cargo install diesel_cli --force

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -17,4 +17,12 @@ rustup override set nightly
 
 cargo install diesel_cli --force
 
-sudo npm install -g brunch
+# brunch
+if [[ "$OSTYPE" == "linux-gnu" ]]; then
+	# Linux
+	sudo npm install -g brunch
+elif [[ "$OSTYPE" == "darwin"* ]]; then
+	# macOS
+	# Let’s assume npm was installed via homebrew
+ 	npm install -g brunch
+fi

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -1,9 +1,5 @@
 #!/bin/bash -ex
 
-if [ -z $DATABASE_URL ]; then
-  echo "DATABASE_URL is not set. Aborting."
-  exit 1;
-fi
 
 command -v rustup >/dev/null 2>&1 || { echo 'I require `rustup` but it’s not installed. Install it with `curl https://sh.rustup.rs -sSf | sh`. Aborting.' >&2; exit 1; }
 

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -12,9 +12,11 @@ else
     exit 1;
 fi
 
+# rustup
 command -v rustup >/dev/null 2>&1 || { echo 'I require `rustup` but it’s not installed. Install it with `curl https://sh.rustup.rs -sSf | sh`. Aborting.' >&2; exit 1; }
 rustup override set nightly
 
+# diesel_cli
 cargo install diesel_cli --force
 
 # brunch


### PR DESCRIPTION
I don’t know if it _runs_ correctly, but at least it builds on my machine.

The most annoying thing is for openssl, which required me to add environment variables. I would have preferred adding keys in Cargo.toml, as per http://stackoverflow.com/a/38946292. I only got cargo to complain about `warning: unused manifest key`, not 100% sure why.