### PR TITLE
Add 2 linter filters

### DIFF
--- a/src/linter/filters/mod.rs
+++ b/src/linter/filters/mod.rs
@@ -1,10 +1,12 @@
 pub mod curly_apostrophe_filter;
 pub mod ellipsis_symbol_filter;
+pub mod space_before_double_ponctuation_filter;
 
 use super::*;
 
 pub use self::curly_apostrophe_filter::CurlyApostropheFilter;
 pub use self::ellipsis_symbol_filter::EllipsisSymbolFilter;
+pub use self::space_before_double_ponctuation_filter::SpaceBeforeDoublePonctuationFilter;
 
 pub trait LinterFilter {
     fn check(&self, text: &str) -> Result<(), Vec<LinterWarning>> {

--- a/src/linter/filters/mod.rs
+++ b/src/linter/filters/mod.rs
@@ -1,11 +1,13 @@
 pub mod curly_apostrophe_filter;
 pub mod ellipsis_symbol_filter;
+pub mod no_space_before_comma_filter;
 pub mod space_before_double_ponctuation_filter;
 
 use super::*;
 
 pub use self::curly_apostrophe_filter::CurlyApostropheFilter;
 pub use self::ellipsis_symbol_filter::EllipsisSymbolFilter;
+pub use self::no_space_before_comma_filter::NoSpaceBeforeCommaFilter;
 pub use self::space_before_double_ponctuation_filter::SpaceBeforeDoublePonctuationFilter;
 
 pub trait LinterFilter {

--- a/src/linter/filters/no_space_before_comma_filter.rs
+++ b/src/linter/filters/no_space_before_comma_filter.rs
@@ -1,0 +1,45 @@
+use super::*;
+
+pub struct NoSpaceBeforeCommaFilter {}
+
+impl LinterFilter for NoSpaceBeforeCommaFilter {
+    fn message(&self) -> &'static str {
+        "Please don’t use a space before a comma."
+    }
+
+    fn regex_pattern(&self) -> &'static str {
+        r"\s+,"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_filter_with_no_warnings() {
+        let filter = NoSpaceBeforeCommaFilter {};
+
+        let result = filter.check("Lorsqu’on le lui demande, il répond qu’il se nomme Simbad le marin.");
+
+        assert_eq!(false, result.is_err());
+        assert_eq!((), result.unwrap());
+    }
+
+    #[test]
+    fn test_filter_with_a_warning() {
+        let filter = NoSpaceBeforeCommaFilter {};
+
+        let result = filter.check("Lorsqu’on le lui demande , il répond qu’il se nomme Simbad le marin.");
+
+        assert!(result.is_err());
+
+        let warnings = result.err().unwrap();
+
+        assert_eq!(1, warnings.len());
+        assert_eq!("Please don’t use a space before a comma.", warnings[0].message);
+        assert_eq!(26, warnings[0].start);
+        assert_eq!(28, warnings[0].end);
+    }
+}
+

--- a/src/linter/filters/space_before_double_ponctuation_filter.rs
+++ b/src/linter/filters/space_before_double_ponctuation_filter.rs
@@ -1,0 +1,80 @@
+use super::*;
+
+pub struct SpaceBeforeDoublePonctuationFilter {}
+
+impl LinterFilter for SpaceBeforeDoublePonctuationFilter {
+    fn locales(&self) -> Vec<&'static str> {
+        vec!["fr"]
+    }
+
+    fn message(&self) -> &'static str {
+        "Please use a non-breaking space before “double” ponctuation marks: `;`, `:`, `!`, `?`."
+    }
+
+    fn regex_pattern(&self) -> &'static str {
+        r"[\w ][;:!?]"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_filter_with_no_warnings() {
+        let filter = SpaceBeforeDoublePonctuationFilter {};
+
+        let result = filter.check("Ah ! Non ! C’est un peu court, jeune homme !");
+
+        assert_eq!(false, result.is_err());
+        assert_eq!((), result.unwrap());
+    }
+
+    #[test]
+    fn test_filter_with_two_warnings() {
+        let filter = SpaceBeforeDoublePonctuationFilter {};
+
+        let result = filter.check("Ah! Non! C’est un peu court, jeune homme !");
+
+        assert!(result.is_err());
+
+        let warnings = result.err().unwrap();
+
+        assert_eq!(2, warnings.len());
+
+        assert_eq!(
+            "Please use a non-breaking space before “double” ponctuation marks: `;`, `:`, `!`, `?`.",
+            warnings[0].message
+        );
+        assert_eq!(1, warnings[0].start);
+        assert_eq!(3, warnings[0].end);
+
+        assert_eq!(
+            "Please use a non-breaking space before “double” ponctuation marks: `;`, `:`, `!`, `?`.",
+            warnings[1].message
+        );
+        assert_eq!(6, warnings[1].start);
+        assert_eq!(8, warnings[1].end);
+    }
+
+    #[test]
+    fn test_filter_with_a_missing_non_breaking_space() {
+        let filter = SpaceBeforeDoublePonctuationFilter {};
+
+        // The space before the last `!` is not a non-breaking space
+        let result = filter.check("Ah ! Non ! C’est un peu court, jeune homme !");
+
+        assert!(result.is_err());
+
+        let warnings = result.err().unwrap();
+
+        assert_eq!(1, warnings.len());
+        assert_eq!(
+            "Please use a non-breaking space before “double” ponctuation marks: `;`, `:`, `!`, `?`.",
+            warnings[0].message
+        );
+        assert_eq!(46, warnings[0].start);
+        assert_eq!(48, warnings[0].end);
+    }
+}
+

--- a/src/linter/mod.rs
+++ b/src/linter/mod.rs
@@ -29,6 +29,7 @@ impl Linter {
         let filters: Vec<Box<LinterFilter>> = vec![
             Box::new(CurlyApostropheFilter {}),
             Box::new(EllipsisSymbolFilter {}),
+            Box::new(NoSpaceBeforeCommaFilter {}),
             Box::new(SpaceBeforeDoublePonctuationFilter {}),
         ];
 

--- a/src/linter/mod.rs
+++ b/src/linter/mod.rs
@@ -26,20 +26,7 @@ impl Linter {
     pub fn check(&self, text: &str) -> Result<(), Vec<LinterWarning>> {
         let mut warnings = Vec::<LinterWarning>::new();
 
-        let filters: Vec<Box<LinterFilter>> = vec![
-            Box::new(CurlyApostropheFilter {}),
-            Box::new(EllipsisSymbolFilter {}),
-            Box::new(NoSpaceBeforeCommaFilter {}),
-            Box::new(SpaceBeforeDoublePonctuationFilter {}),
-        ];
-
-        let active_filters = filters
-            .into_iter()
-            .filter( |filter| filter.locales().is_empty() ||
-                filter.locales().contains(&self.locale.as_str()) )
-            .collect::<Vec<Box<LinterFilter>>>();
-
-        for filter in &active_filters {
+        for filter in &self.active_filters(self.locale.as_str()) {
             let result = filter.check(text);
 
             if result.is_err() {
@@ -52,6 +39,22 @@ impl Linter {
         } else {
             Err(warnings)
         }
+    }
+
+    fn active_filters(&self, locale: &str) -> Vec<Box<LinterFilter>> {
+        self.filters()
+            .into_iter()
+            .filter(|filter| filter.locales().is_empty() || filter.locales().contains(&locale))
+            .collect()
+    }
+
+    fn filters(&self) -> Vec<Box<LinterFilter>> {
+        vec![
+            Box::new(CurlyApostropheFilter {}),
+            Box::new(EllipsisSymbolFilter {}),
+            Box::new(NoSpaceBeforeCommaFilter {}),
+            Box::new(SpaceBeforeDoublePonctuationFilter {}),
+        ]
     }
 }
 


### PR DESCRIPTION
Add new linter filters:
- `NoSpaceBeforeCommaFilter` (all locales);
- `SpaceBeforeDoublePonctuationFilter` (fr only).

@Signez, could you please review?