### PR TITLE
Pass some argument as reference instead of value

### DIFF
--- a/src/api/v1/sessions.rs
+++ b/src/api/v1/sessions.rs
@@ -30,7 +30,7 @@ pub fn logout(request: &mut Request) -> IronResult<Response> {
 
     let current_session = request.extensions.get::<Session>().unwrap();
 
-    delete_session(current_session.token.to_string())?;
+    delete_session(current_session.token.as_str())?;
 
     Ok(Response::with((ContentType::json().0, status::NoContent)))
 }

--- a/src/authentication/mod.rs
+++ b/src/authentication/mod.rs
@@ -62,7 +62,7 @@ pub fn create_user(new_email: &str, new_password: &str) -> Result<User, LughErro
     Ok(inserted_user)
 }
 
-pub fn delete_session(token_to_delete: String) -> Result<(), LughError> {
+pub fn delete_session(token_to_delete: &str) -> Result<(), LughError> {
     use diesel;
     use schema::sessions::dsl::*;
 
@@ -243,9 +243,7 @@ mod tests {
 
     #[test]
     fn test_delete_session_when_success() {
-        let token = "tokentodelete".to_string();
-
-        let result = delete_session(token);
+        let result = delete_session("tokentodelete");
 
         assert_eq!(false, result.is_err());
         assert_eq!((), result.unwrap());
@@ -253,9 +251,7 @@ mod tests {
 
     #[test]
     fn test_delete_session_when_token_does_not_exist() {
-        let token = "nonexistingtoken".to_string();
-
-        let result = delete_session(token);
+        let result = delete_session("nonexistingtoken");
 
         assert!(result.is_err());
         assert_eq!(LughError::NotFound("No session were deleted".to_string()), result.err().unwrap())

--- a/tests/api/v1/common.rs
+++ b/tests/api/v1/common.rs
@@ -3,7 +3,7 @@ use hyper::client::Response;
 use hyper::header::Headers;
 use std::io::Read;
 
-pub fn delete(path: &'static str, token: Option<String>) -> (Response, String) {
+pub fn delete(path: &'static str, token: &Option<String>) -> (Response, String) {
     let mut response = Client::new()
         .delete(&url(path))
         .headers(headers(token))
@@ -16,7 +16,7 @@ pub fn delete(path: &'static str, token: Option<String>) -> (Response, String) {
     (response, content)
 }
 
-pub fn get(path: &'static str, token: Option<String>) -> (Response, String) {
+pub fn get(path: &'static str, token: &Option<String>) -> (Response, String) {
     let mut response = Client::new()
         .get(&url(path))
         .headers(headers(token))
@@ -29,13 +29,13 @@ pub fn get(path: &'static str, token: Option<String>) -> (Response, String) {
     (response, result)
 }
 
-pub fn post(path: &'static str, body: Option<String>, token: Option<String>) -> (Response, String) {
+pub fn post(path: &'static str, body: &Option<String>, token: &Option<String>) -> (Response, String) {
     let client = Client::new();
 
     let mut request = client.post(&url(path))
         .headers(headers(token));
 
-    request = match body {
+    request = match *body {
         Some(ref body) => request.body(body),
         None => request,
     };
@@ -71,14 +71,14 @@ pub fn has_happened_now(time_str: &str) -> bool {
     time > min && time <= now
 }
 
-fn headers(token: Option<String>) -> Headers {
+fn headers(token: &Option<String>) -> Headers {
     use hyper::header::{Authorization, Bearer, ContentType, Headers};
     use hyper::mime::{Mime, TopLevel, SubLevel, Attr, Value};
 
     let mut headers = Headers::new();
 
-    if let Some(token) = token {
-        headers.set(Authorization(Bearer { token: token }))
+    if let Some(ref token) = *token {
+        headers.set(Authorization(Bearer { token: token.to_string() }))
     }
 
     headers.set(

--- a/tests/api/v1/configuration.rs
+++ b/tests/api/v1/configuration.rs
@@ -12,7 +12,7 @@ mod tests {
 
     #[test]
     fn test_get_configuration_without_token() {
-        let (response, content) = get("/api/v1/configuration", None);
+        let (response, content) = get("/api/v1/configuration", &None);
 
         assert_eq!(StatusCode::Unauthorized, response.status);
         assert_eq!("", content)
@@ -20,7 +20,7 @@ mod tests {
 
     #[test]
     fn test_get_configuration_with_success() {
-        let (response, content) = get("/api/v1/configuration", valid_token());
+        let (response, content) = get("/api/v1/configuration", &valid_token());
         let configuration = parse_configuration(&content);
 
         assert_eq!(StatusCode::Ok, response.status);

--- a/tests/api/v1/mod.rs
+++ b/tests/api/v1/mod.rs
@@ -12,7 +12,7 @@ mod tests {
 
     #[test]
     fn test_index() {
-        let (response, result) = get("/api/v1", valid_token());
+        let (response, result) = get("/api/v1", &valid_token());
 
         assert_eq!(response.status, StatusCode::Ok);
         assert_eq!(result, "Welcome to Lugh API!");
@@ -20,7 +20,7 @@ mod tests {
 
     #[test]
     fn test_index_without_token() {
-        let (response, result) = get("/api/v1", None);
+        let (response, result) = get("/api/v1", &None);
 
         assert_eq!(response.status, StatusCode::Unauthorized);
         assert_eq!(result, "");
@@ -28,7 +28,7 @@ mod tests {
 
     #[test]
     fn test_index_with_a_bad_token() {
-        let (response, result) = get("/api/v1", Some("badtoken".to_string()));
+        let (response, result) = get("/api/v1", &Some("badtoken".to_string()));
 
         assert_eq!(response.status, StatusCode::Unauthorized);
         assert_eq!(result, "");

--- a/tests/api/v1/sessions.rs
+++ b/tests/api/v1/sessions.rs
@@ -21,7 +21,7 @@ mod tests {
 
     #[test]
     fn test_login_without_body() {
-        let (response, content) = post("/api/v1/login", None, None);
+        let (response, content) = post("/api/v1/login", &None, &None);
 
         assert_eq!(StatusCode::BadRequest, response.status);
         assert_eq!("", content)
@@ -34,7 +34,7 @@ mod tests {
             password: Some("testpassword"),
         };
 
-        let (response, _) = login(login_params);
+        let (response, _) = login(&login_params);
 
         assert_eq!(StatusCode::BadRequest, response.status);
     }
@@ -46,7 +46,7 @@ mod tests {
             password: None,
         };
 
-        let (response, _) = login(login_params);
+        let (response, _) = login(&login_params);
 
         assert_eq!(StatusCode::BadRequest, response.status);
     }
@@ -58,7 +58,7 @@ mod tests {
             password: Some("wrongpassword"),
         };
 
-        let (response, _) = login(login_params);
+        let (response, _) = login(&login_params);
 
         assert_eq!(StatusCode::Unauthorized, response.status);
     }
@@ -72,7 +72,7 @@ mod tests {
             password: Some("testpassword"),
         };
 
-        let (response, content) = login(login_params);
+        let (response, content) = login(&login_params);
 
         assert_eq!(StatusCode::Created, response.status);
 
@@ -84,13 +84,13 @@ mod tests {
         let expired_at = time::strptime(session.expired_at.as_str(), "%F %T").unwrap();
         assert!(expired_at > time::now_utc());
 
-        let (response, content) = post("/api/v1/logout", None, Some(session.token.clone()));
+        let (response, content) = post("/api/v1/logout", &None, &Some(session.token.clone()));
 
         assert_eq!(StatusCode::NoContent, response.status);
         assert_eq!("", content);
 
         // We check that we are disconnected
-        let (response, content) = post("/api/v1/logout", None, Some(session.token));
+        let (response, content) = post("/api/v1/logout", &None, &Some(session.token));
 
         assert_eq!(StatusCode::Unauthorized, response.status);
         assert_eq!("", content);
@@ -98,15 +98,15 @@ mod tests {
 
     #[test]
     fn test_logout_without_token() {
-        let (response, content) = post("/api/v1/logout", None, None);
+        let (response, content) = post("/api/v1/logout", &None, &None);
 
         assert_eq!(StatusCode::Unauthorized, response.status);
         assert_eq!("", content);
     }
 
-    fn login(params: LoginParams) -> (Response, String) {
+    fn login(params: &LoginParams) -> (Response, String) {
         let body = json::encode(&params).unwrap();
 
-        post("/api/v1/login", Some(body), None)
+        post("/api/v1/login", &Some(body), &None)
     }
 }

--- a/tests/api/v1/translations.rs
+++ b/tests/api/v1/translations.rs
@@ -58,7 +58,7 @@ mod tests {
 
     #[test]
     fn test_create_without_body() {
-        let (response, content) = post("/api/v1/translations", None, valid_token());
+        let (response, content) = post("/api/v1/translations", &None, &valid_token());
 
         assert_eq!(StatusCode::BadRequest, response.status);
         assert_eq!("", content)
@@ -72,7 +72,7 @@ mod tests {
             content: Some("I love train"),
         };
 
-        let (response, content) = post_translation(new_translation, None);
+        let (response, content) = post_translation(&new_translation, &None);
 
         assert_eq!(StatusCode::Unauthorized, response.status);
         assert_eq!("", content)
@@ -86,7 +86,7 @@ mod tests {
             content: Some("I love train"),
         };
 
-        let (response, _) = post_translation(new_translation, valid_token());
+        let (response, _) = post_translation(&new_translation, &valid_token());
 
         assert_eq!(StatusCode::BadRequest, response.status);
     }
@@ -99,7 +99,7 @@ mod tests {
             content: Some("I love train"),
         };
 
-        let (response, _) = post_translation(new_translation, valid_token());
+        let (response, _) = post_translation(&new_translation, &valid_token());
 
         assert_eq!(StatusCode::BadRequest, response.status);
     }
@@ -112,7 +112,7 @@ mod tests {
             content: None,
         };
 
-        let (response, _) = post_translation(new_translation, valid_token());
+        let (response, _) = post_translation(&new_translation, &valid_token());
 
         assert_eq!(StatusCode::BadRequest, response.status);
     }
@@ -120,7 +120,7 @@ mod tests {
     #[test]
     fn test_insert_and_delete() {
         // We fetch all translations
-        let (response, content) = get("/api/v1/translations", valid_token());
+        let (response, content) = get("/api/v1/translations", &valid_token());
 
         assert_eq!(StatusCode::Ok, response.status);
 
@@ -131,12 +131,12 @@ mod tests {
 
         // We create new translations on key `test.hello`
         let (response, content) = post_translation(
-            NewTranslation {
+            &NewTranslation {
                 key: Some("test.hello"),
                 locale: Some("fr"),
                 content: Some("Bonjour"),
             },
-            valid_token()
+            &valid_token()
         );
 
         assert_eq!(StatusCode::Created, response.status);
@@ -153,12 +153,12 @@ mod tests {
         assert_eq!(true, create_response.warnings.is_empty());
 
         let (response, content) = post_translation(
-            NewTranslation {
+            &NewTranslation {
                 key: Some("test.hello"),
                 locale: Some("en"),
                 content: Some("Hello"),
             },
-            valid_token()
+            &valid_token()
         );
 
         assert_eq!(StatusCode::Created, response.status);
@@ -176,12 +176,12 @@ mod tests {
 
         // We insert a translation with 2 linter warnings
         let (response, content) = post_translation(
-            NewTranslation {
+            &NewTranslation {
                 key: Some("test.me"),
                 locale: Some("en"),
                 content: Some("It's me..."),
             },
-            valid_token()
+            &valid_token()
         );
 
         assert_eq!(StatusCode::Created, response.status);
@@ -207,7 +207,7 @@ mod tests {
         assert_eq!(10, warnings[1].end);
 
         // We fetch all translations
-        let (response, content) = get("/api/v1/translations", valid_token());
+        let (response, content) = get("/api/v1/translations", &valid_token());
 
         assert_eq!(StatusCode::Ok, response.status);
 
@@ -219,14 +219,14 @@ mod tests {
         assert_eq!(1, translations_2.get(&"test.me".to_string()).unwrap().len());
 
         // We delete all translations with key equals to `test.hello`
-        let (response, content) = delete("/api/v1/translations/test.hello", valid_token());
+        let (response, content) = delete("/api/v1/translations/test.hello", &valid_token());
         let result: DeletedResult = json::decode(&content).unwrap();
 
         assert_eq!(StatusCode::Ok, response.status);
         assert_eq!(2, result.deleted_translations);
 
         // We fetch all translations
-        let (response, content) = get("/api/v1/translations", valid_token());
+        let (response, content) = get("/api/v1/translations", &valid_token());
 
         assert_eq!(StatusCode::Ok, response.status);
 
@@ -237,7 +237,7 @@ mod tests {
         assert_eq!(1, translations_3.get(&"test.me".to_string()).unwrap().len());
 
         // We fetch all translations with key `test.hello`
-        let (response, content) = get("/api/v1/translations/test.hello", valid_token());
+        let (response, content) = get("/api/v1/translations/test.hello", &valid_token());
 
         assert_eq!(StatusCode::Ok, response.status);
 
@@ -252,7 +252,7 @@ mod tests {
 
     #[test]
     fn test_validate_without_token() {
-        let (response, content) = post("/api/v1/translations/1/validate", None, None);
+        let (response, content) = post("/api/v1/translations/1/validate", &None, &None);
 
         assert_eq!(StatusCode::Unauthorized, response.status);
         assert_eq!("", content);
@@ -260,7 +260,7 @@ mod tests {
 
     #[test]
     fn test_validate_when_not_found() {
-        let (response, content) = post("/api/v1/translations/999999/validate", None, valid_token());
+        let (response, content) = post("/api/v1/translations/999999/validate", &None, &valid_token());
 
         assert_eq!(StatusCode::NotFound, response.status);
         assert_eq!("", content);
@@ -269,7 +269,7 @@ mod tests {
     #[test]
     fn test_validate_with_success() {
         // We fetch all translations
-        let (response, content) = get("/api/v1/translations", valid_token());
+        let (response, content) = get("/api/v1/translations", &valid_token());
 
         assert_eq!(StatusCode::Ok, response.status);
 
@@ -281,13 +281,13 @@ mod tests {
         }
 
         // We validate the first translation
-        let (response, content) = post("/api/v1/translations/1/validate", None, valid_token());
+        let (response, content) = post("/api/v1/translations/1/validate", &None, &valid_token());
 
         assert_eq!(StatusCode::NoContent, response.status);
         assert_eq!("", content);
 
         // We fetch all translations
-        let (response, content) = get("/api/v1/translations", valid_token());
+        let (response, content) = get("/api/v1/translations", &valid_token());
 
         assert_eq!(StatusCode::Ok, response.status);
 
@@ -314,7 +314,7 @@ mod tests {
 
     #[test]
     fn test_delete_without_token() {
-        let (response, content) = delete("/api/v1/translations/hey.you", None);
+        let (response, content) = delete("/api/v1/translations/hey.you", &None);
 
         assert_eq!(StatusCode::Unauthorized, response.status);
         assert_eq!("", content);
@@ -322,7 +322,7 @@ mod tests {
 
     #[test]
     fn test_delete_with_a_key_without_translations() {
-        let (response, content) = delete("/api/v1/translations/not.found.key", valid_token());
+        let (response, content) = delete("/api/v1/translations/not.found.key", &valid_token());
         let result: DeletedResult = json::decode(&content).unwrap();
 
         assert_eq!(StatusCode::NotFound, response.status);
@@ -341,9 +341,9 @@ mod tests {
         json::decode(content).unwrap()
     }
 
-    fn post_translation(translation: NewTranslation, token: Option<String>) -> (Response, String) {
+    fn post_translation(translation: &NewTranslation, token: &Option<String>) -> (Response, String) {
         let body = json::encode(&translation).unwrap();
 
-        post("/api/v1/translations", Some(body), token)
+        post("/api/v1/translations", &Some(body), token)
     }
 }

--- a/tests/api/v1/users.rs
+++ b/tests/api/v1/users.rs
@@ -14,7 +14,7 @@ mod tests {
 
     #[test]
     fn test_create_without_body() {
-        let (response, content) = post("/api/v1/users", None, valid_token());
+        let (response, content) = post("/api/v1/users", &None, &valid_token());
 
         assert_eq!(StatusCode::BadRequest, response.status);
         assert_eq!("", content)
@@ -27,7 +27,7 @@ mod tests {
             password: Some("p4ssw0rd"),
         };
 
-        let (response, content) = post_user(new_user, None);
+        let (response, content) = post_user(&new_user, &None);
 
         assert_eq!(StatusCode::Unauthorized, response.status);
         assert_eq!("", content);
@@ -40,7 +40,7 @@ mod tests {
             password: Some("p4ssw0rd"),
         };
 
-        let (response, _) = post_user(new_user, valid_token());
+        let (response, _) = post_user(&new_user, &valid_token());
 
         assert_eq!(StatusCode::BadRequest, response.status);
     }
@@ -52,7 +52,7 @@ mod tests {
             password: None,
         };
 
-        let (response, _) = post_user(new_user, valid_token());
+        let (response, _) = post_user(&new_user, &valid_token());
 
         assert_eq!(StatusCode::BadRequest, response.status);
     }
@@ -64,14 +64,14 @@ mod tests {
             password: Some("p4ssw0rd"),
         };
 
-        let (response, _) = post_user(new_user, valid_token());
+        let (response, _) = post_user(&new_user, &valid_token());
 
         assert_eq!(StatusCode::Created, response.status);
     }
 
-    fn post_user(user: NewUser, token: Option<String>) -> (Response, String) {
+    fn post_user(user: &NewUser, token: &Option<String>) -> (Response, String) {
         let body = json::encode(&user).unwrap();
 
-        post("/api/v1/users", Some(body), token)
+        post("/api/v1/users", &Some(body), token)
     }
 }


### PR DESCRIPTION
As they are not consumed in their function body. It fixes _needless_pass_by_value clippy_ warning.