### PR TITLE
Add simple way to delete a translation

### DIFF
--- a/src/frontend/app/components/translation-key.vue
+++ b/src/frontend/app/components/translation-key.vue
@@ -8,6 +8,9 @@
     --><i class="fa fa-fw fa-file-o" style="margin-right: 3px" v-if="index == crumbs.length - 1"></i><!--
     -->{{ crumb }}<!--
     --></span>
+    <button class="translation-key-delete" @click="deleteTranslation">
+      <i class="fa fa-fw fa-trash-o" />
+    </button>
   </div>
 </template>
 
@@ -22,6 +25,24 @@
     computed: {
       crumbs() {
         return this.translationKey.split('.');
+      }
+    },
+
+    methods: {
+      deleteTranslation() {
+        let confirmation = window.confirm(`You will destroy ${this.translationKey}; are you sure?`);
+
+        if (confirmation) {
+          this.$root.$data.callApi(`/api/v1/translations/${this.translationKey}`, 'DELETE').then(response => {
+            if (response.ok) {
+              return response.json();
+            } else {
+              window.alert("An error occured while deleting the translation.");
+            }
+          }).then(data => {
+            this.$root.$data.fetchTranslations();
+          });
+        }
       }
     }
   });

--- a/src/frontend/app/styles/translation-key.css
+++ b/src/frontend/app/styles/translation-key.css
@@ -13,3 +13,21 @@
 .translation-crumb-separator span {
   font-size: 0;
 }
+
+.translation-key-delete {
+  float: right;
+  border: 1px solid currentColor;
+  background: transparent;
+  padding: 2px;
+  margin-top: -2px;
+  margin-bottom: -2px;
+  vertical-align: bottom;
+  border-radius: 2px;
+
+  color: #850101;
+}
+
+.translation-key-delete:focus,
+.translation-key-delete:active {
+  box-shadow: 0 0 0 1px #850101 inset;
+}


### PR DESCRIPTION
This simply add a little trash icon on the right of the key name; a click simply delete the translation after confirmation.

@rlustin Please review and merge.